### PR TITLE
Add net-tools to prepare script

### DIFF
--- a/lgs-install.sh
+++ b/lgs-install.sh
@@ -255,7 +255,7 @@ fi
 function prepare_system() {
 echo -e "Prepare the system to install ${GREEN}$COIN_NAME${NC} master node."
 apt-get update >/dev/null 2>&1
-apt-get install -y wget curl binutils >/dev/null 2>&1
+apt-get install -y wget curl binutils net-tools >/dev/null 2>&1
 }
 
 function important_information() {


### PR DESCRIPTION
Add net-tools to prepare script in case netstat is not installed by default (ProxMox containers do not necessarily have this by default for example)